### PR TITLE
logrus import url lowercased

### DIFF
--- a/telegram_hook.go
+++ b/telegram_hook.go
@@ -8,7 +8,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 // TelegramHook to send logs via the Telegram API.


### PR DESCRIPTION
Currently installing this package with the `dep` package manager fails. This change is in accordance with sirupsen/logrus#570 which **strongly** suggests all packages use the lowercase URL.