### PR TITLE
Add Asynchronous and Timeout options

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ See the tests for working examples. Also:
 
 ```go
 import (
+	"time"
 	log "github.com/Sirupsen/logrus"
 	"github.com/rossmcdonald/telegram_hook"
 )
@@ -34,6 +35,8 @@ func main() {
 		"MyCoolApp",
 		"MYTELEGRAMTOKEN",
 		"@mycoolusername",
+		telegram_hook.WithAsync(true),
+		telegram_hook.WithTimeout(30 * time.Second),
 	)
 	if err != nil {
 		log.Fatalf("Encountered error when creating Telegram hook: %s", err)

--- a/telegram_hook.go
+++ b/telegram_hook.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/sirupsen/logrus"
 )
@@ -18,6 +19,7 @@ type TelegramHook struct {
 	authToken   string
 	targetID    string
 	apiEndpoint string
+	async bool
 }
 
 // apiRequest encapsulates the request structure we are sending to the
@@ -37,9 +39,12 @@ type apiResponse struct {
 	Result    *interface{} `json:"result,omitempty"`
 }
 
+// Config defines a method for additional configuration when instantiating TelegramHook
+type Config func(*TelegramHook)
+
 // NewTelegramHook creates a new instance of a hook targeting the
 // Telegram API.
-func NewTelegramHook(appName, authToken, targetID string) (*TelegramHook, error) {
+func NewTelegramHook(appName, authToken, targetID string, config ...Config) (*TelegramHook, error) {
 	client := http.Client{}
 	apiEndpoint := fmt.Sprintf(
 		"https://api.telegram.org/bot%s",
@@ -51,6 +56,11 @@ func NewTelegramHook(appName, authToken, targetID string) (*TelegramHook, error)
 		authToken:   authToken,
 		targetID:    targetID,
 		apiEndpoint: apiEndpoint,
+		async: false,
+	}
+
+	for _, c := range config {
+		c(&h)
 	}
 
 	// Verify the API token is valid and correct before continuing
@@ -60,6 +70,22 @@ func NewTelegramHook(appName, authToken, targetID string) (*TelegramHook, error)
 	}
 
 	return &h, nil
+}
+
+// Async sets logging to telegram as asynchronous
+func Async(b bool) Config {
+	return func(hook *TelegramHook) {
+		hook.async = b
+	}
+}
+
+// Timeout sets http call timeout for telegram client
+func Timeout(t time.Duration) Config {
+	return func(hook *TelegramHook) {
+		if t > 0 {
+			hook.c.Timeout = t
+		}
+	}
 }
 
 // verifyToken issues a test request to the Telegram API to ensure the
@@ -167,6 +193,12 @@ func (hook *TelegramHook) createMessage(entry *logrus.Entry) string {
 // Fire emits a log message to the Telegram API.
 func (hook *TelegramHook) Fire(entry *logrus.Entry) error {
 	msg := hook.createMessage(entry)
+
+	if hook.async {
+		go hook.sendMessage(msg)
+		return nil
+	}
+
 	err := hook.sendMessage(msg)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Unable to send message, %v", err)

--- a/telegram_hook.go
+++ b/telegram_hook.go
@@ -73,14 +73,14 @@ func NewTelegramHook(appName, authToken, targetID string, config ...Config) (*Te
 }
 
 // Async sets logging to telegram as asynchronous
-func Async(b bool) Config {
+func WithAsync(b bool) Config {
 	return func(hook *TelegramHook) {
 		hook.async = b
 	}
 }
 
 // Timeout sets http call timeout for telegram client
-func Timeout(t time.Duration) Config {
+func WithTimeout(t time.Duration) Config {
 	return func(hook *TelegramHook) {
 		if t > 0 {
 			hook.c.Timeout = t


### PR DESCRIPTION
This pull request add the ability to call telegram asynchronously and to set  timeout for http call.
The `NewTelegramHook` still backward compatible.