### PR TITLE
add new constructor with custom http.Client

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,44 @@ func main() {
 }
 ```
 
+Also you can set custom http.Client to use SOCKS5 proxy for example
+
+```go
+import (
+	"time"
+	"net/http"
+	
+	"golang.org/x/net/proxy"
+	log "github.com/Sirupsen/logrus"
+	"github.com/rossmcdonald/telegram_hook"
+)
+
+func main() {
+	httpTransport := &http.Transport{}
+    httpClient := &http.Client{Transport: httpTransport}
+    dialer, err := proxy.SOCKS5("tcp", "127.0.0.1:54321", nil, proxy.Direct)
+    httpTransport.Dial = dialer.Dial
+    
+	hook, err := telegram_hook.NewTelegramHookWithClient(
+		"MyCoolApp",
+		"MYTELEGRAMTOKEN",
+		"@mycoolusername",
+		httpClient,
+		telegram_hook.WithAsync(true),
+		telegram_hook.WithTimeout(30 * time.Second),
+	)
+	if err != nil {
+		log.Fatalf("Encountered error when creating Telegram hook: %s", err)
+	}
+	log.AddHook(hook)
+	
+	// Receive messages on failures
+	log.Errorf("Uh oh...")
+	...
+	
+}
+```
+
 ## License
 
 MIT

--- a/telegram_hook.go
+++ b/telegram_hook.go
@@ -45,14 +45,20 @@ type Config func(*TelegramHook)
 // NewTelegramHook creates a new instance of a hook targeting the
 // Telegram API.
 func NewTelegramHook(appName, authToken, targetID string, config ...Config) (*TelegramHook, error) {
-	client := http.Client{}
+	client := &http.Client{}
+	return NewTelegramHookWithClient(appName, authToken, targetID, client, config...)
+}
+
+// NewTelegramHook creates a new instance of a hook targeting the
+// Telegram API with custom http.Client.
+func NewTelegramHookWithClient(appName, authToken, targetID string, client *http.Client, config ...Config) (*TelegramHook, error) {
 	apiEndpoint := fmt.Sprintf(
 		"https://api.telegram.org/bot%s",
 		authToken,
 	)
 	h := TelegramHook{
 		AppName:     appName,
-		c:           &client,
+		c:           client,
 		authToken:   authToken,
 		targetID:    targetID,
 		apiEndpoint: apiEndpoint,


### PR DESCRIPTION
Telegram api was blocked in Russia that's why we need new hook constructor with custom http.Client.