### PR TITLE
Fix 'WithError' errors showing up as {}.

### DIFF
--- a/telegram_hook.go
+++ b/telegram_hook.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"html"
 	"net/http"
 	"os"
 	"strings"
@@ -187,10 +188,11 @@ func (hook *TelegramHook) createMessage(entry *logrus.Entry) string {
 
 	msg = strings.Join([]string{msg, hook.AppName}, "@")
 	msg = strings.Join([]string{msg, entry.Message}, " - ")
-	fields, err := json.MarshalIndent(entry.Data, "", "\t")
-	if err == nil {
+	if len(entry.Data) > 0 {
 		msg = strings.Join([]string{msg, "<pre>"}, "\n")
-		msg = strings.Join([]string{msg, string(fields)}, "\n")
+		for k, v := range entry.Data {
+			msg = strings.Join([]string{msg, html.EscapeString(fmt.Sprintf("\t%s: %+v", k, v))}, "\n")
+		}
 		msg = strings.Join([]string{msg, "</pre>"}, "\n")
 	}
 	return msg

--- a/telegram_hook_test.go
+++ b/telegram_hook_test.go
@@ -1,6 +1,7 @@
 package telegram_hook_test
 
 import (
+	"errors"
 	"os"
 	"testing"
 
@@ -25,9 +26,10 @@ func TestNewHook(t *testing.T) {
 	}
 	log.AddHook(h)
 
-	log.WithFields(log.Fields{
+	log.WithError(errors.New("an error")).WithFields(log.Fields{
 		"animal": "walrus",
 		"number": 1,
 		"size":   10,
+		"html":   "<b>bold</b>",
 	}).Errorf("A walrus appears")
 }


### PR DESCRIPTION
This changes the field output from being done via JSON encoding to just doing it ourselves with fmt.Sprintf and the %+v formatter. This will also help displaying struct types in general.

Fixes #6.

New output from test:

```
ERROR@testing - A walrus appears

 error: an error
 number: 1
 size: 10
 html: <b>bold</b>
 animal: walrus
```